### PR TITLE
Preparation for library based QR-Code generation - setup identifier 

### DIFF
--- a/include/mgos_hap.h
+++ b/include/mgos_hap.h
@@ -105,14 +105,17 @@ bool mgos_hap_setup_info_from_string(
         const char* _Nonnull salt,
         const char* _Nonnull verifier);
 
+/*
+ * Load setup identifier from string.
+ */
+bool mgos_hap_setup_id_from_string(HAPSetupID* _Nonnull setupID, const char* setup_id);
+
 #ifdef MGOS_HAP_SIMPLE_CONFIG
 bool mgos_hap_config_valid(void);
 
 #ifdef MGOS_HAVE_RPC_COMMON
 // Simple case: only one primary accessory, constant.
-void mgos_hap_add_rpc_service(
-        HAPAccessoryServerRef* _Nonnull server,
-        const HAPAccessory* _Nonnull accessory);
+void mgos_hap_add_rpc_service(HAPAccessoryServerRef* _Nonnull server, const HAPAccessory* _Nonnull accessory);
 // More complicated variant.
 void mgos_hap_add_rpc_service_cb(
         HAPAccessoryServerRef* _Nonnull server,

--- a/mos.yml
+++ b/mos.yml
@@ -47,6 +47,7 @@ conds:
         - ["hap", "o", {"title": "HAP settings"}]
         - ["hap.salt", "s", "", {"title": "Device verifier salt"}]
         - ["hap.verifier", "s", "", {"title": "Device verifier"}]
+        - ["hap.setupid", "s", "", {"title": "Device setup id (Four characters)"}]
       cdefs:
         MGOS_HAP_SIMPLE_CONFIG: 1
 

--- a/src/PAL/HAPPlatformAccessorySetup.c
+++ b/src/PAL/HAPPlatformAccessorySetup.c
@@ -15,12 +15,43 @@
  * limitations under the License.
  */
 
+#include "mgos.h"
+#include "mgos_hap.h"
+
 #include "HAPPlatformAccessorySetup.h"
 #include "HAPPlatformAccessorySetup+Init.h"
 
 void HAPPlatformAccessorySetupCreate(
         HAPPlatformAccessorySetupRef accessorySetup HAP_UNUSED,
         const HAPPlatformAccessorySetupOptions* options HAP_UNUSED) {
+}
+
+void HAPPlatformAccessorySetupLoadSetupInfo(HAPPlatformAccessorySetupRef accessorySetup, HAPSetupInfo* setupInfo) {
+    struct mgos_hap_load_setup_info_arg arg = {
+        .accessorySetup = accessorySetup,
+        .setupInfo = setupInfo,
+    };
+    mgos_event_trigger(MGOS_HAP_EV_LOAD_SETUP_INFO, &arg);
+}
+
+void HAPPlatformAccessorySetupLoadSetupCode(HAPPlatformAccessorySetupRef accessorySetup, HAPSetupCode* setupCode) {
+    struct mgos_hap_load_setup_code_arg arg = {
+        .accessorySetup = accessorySetup,
+        .setupCode = setupCode,
+    };
+    mgos_event_trigger(MGOS_HAP_EV_LOAD_SETUP_CODE, &arg);
+}
+
+void HAPPlatformAccessorySetupLoadSetupID(
+        HAPPlatformAccessorySetupRef accessorySetup,
+        bool* valid,
+        HAPSetupID* setupID) {
+    struct mgos_hap_load_setup_id_arg arg = {
+        .accessorySetup = accessorySetup,
+        .valid = valid,
+        .setupID = setupID,
+    };
+    mgos_event_trigger(MGOS_HAP_EV_LOAD_SETUP_ID, &arg);
 }
 
 HAPPlatformAccessorySetupCapabilities

--- a/src/PAL/HAPPlatformAccessorySetupDisplay+Init.h
+++ b/src/PAL/HAPPlatformAccessorySetupDisplay+Init.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2015-2019 The HomeKit ADK Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the “License”);
+// you may not use this file except in compliance with the License.
+// See [CONTRIBUTORS.md] for the list of HomeKit ADK project authors.
+
+#ifndef HAP_PLATFORM_ACCESSORY_SETUP_DISPLAY_INIT_H
+#define HAP_PLATFORM_ACCESSORY_SETUP_DISPLAY_INIT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "HAPPlatform.h"
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull begin
+#endif
+
+#ifndef HAVE_DISPLAY
+#define HAVE_DISPLAY 0
+#endif
+
+/**@file
+ * Accessory setup display.
+ *
+ * - The HAPLog APIs are used to display the setup payload and setup code.
+ *   For a real display the implementation needs to be adjusted.
+ *
+ * **Example**
+
+   @code{.c}
+
+   // Allocate Accessory setup display.
+   static HAPPlatformAccessorySetupDisplay setupDisplay;
+
+   // Initialize Accessory setup display.
+   HAPPlatformAccessorySetupDisplayCreate(&setupDisplay);
+
+   @endcode
+*/
+
+/**
+ * Accessory setup display.
+ */
+struct HAPPlatformAccessorySetupDisplay {
+    // Opaque type. Do not access the instance fields directly.
+    /**@cond */
+    HAPSetupPayload setupPayload;
+    HAPSetupCode setupCode;
+    bool setupPayloadIsSet : 1;
+    bool setupCodeIsSet : 1;
+    /**@endcond */
+};
+
+/**
+ * Initializes Accessory setup display.
+ *
+ * @param[out] setupDisplay         Accessory setup display.
+ */
+void HAPPlatformAccessorySetupDisplayCreate(HAPPlatformAccessorySetupDisplayRef setupDisplay);
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/PAL/HAPPlatformAccessorySetupDisplay.c
+++ b/src/PAL/HAPPlatformAccessorySetupDisplay.c
@@ -1,0 +1,54 @@
+// Copyright (c) 2015-2019 The HomeKit ADK Contributors
+// Copyright (c) 2019 Deomid "rojer" Ryabkov
+//
+// Licensed under the Apache License, Version 2.0 (the “License”);
+// you may not use this file except in compliance with the License.
+// See [CONTRIBUTORS.md] for the list of HomeKit ADK project authors.
+
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <stdio.h>
+
+#include "mgos.h"
+#include "mgos_hap.h"
+
+#include "HAPPlatform.h"
+#include "HAPPlatformAccessorySetupDisplay+Init.h"
+
+void HAPPlatformAccessorySetupDisplayCreate(HAPPlatformAccessorySetupDisplayRef setupDisplay) {
+    HAPPrecondition(HAVE_DISPLAY);
+    HAPPrecondition(setupDisplay);
+
+    HAPRawBufferZero(setupDisplay, sizeof *setupDisplay);
+}
+
+void HAPPlatformAccessorySetupDisplayUpdateSetupPayload(
+        HAPPlatformAccessorySetupDisplayRef setupDisplay,
+        const HAPSetupPayload* _Nullable setupPayload,
+        const HAPSetupCode* _Nullable setupCode) {
+
+    struct mgos_hap_display_update_setup_payload_arg arg = {
+        .setupDisplay = setupDisplay,
+        .setupPayload = setupPayload,
+        .setupCode = setupCode,
+    };
+
+    mgos_event_trigger(MGOS_HAP_EV_DISPLAY_UPDATE_SETUP_PAYLOAD, &arg);
+}
+
+void HAPPlatformAccessorySetupDisplayHandleStartPairing(HAPPlatformAccessorySetupDisplayRef setupDisplay) {
+    struct mgos_hap_display_start_pairing_arg arg = {
+        .setupDisplay = setupDisplay,
+    };
+    mgos_event_trigger(MGOS_HAP_EV_DISPLAY_START_PAIRING, &arg);
+}
+
+void HAPPlatformAccessorySetupDisplayHandleStopPairing(HAPPlatformAccessorySetupDisplayRef setupDisplay) {
+    struct mgos_hap_display_stop_pairing_arg arg = {
+        .setupDisplay = setupDisplay,
+    };
+    mgos_event_trigger(MGOS_HAP_EV_DISPLAY_STOP_PAIRING, &arg);
+}

--- a/src/PAL/HAPPlatformAccessorySetupNFC.c
+++ b/src/PAL/HAPPlatformAccessorySetupNFC.c
@@ -1,0 +1,31 @@
+// Copyright (c) 2015-2019 The HomeKit ADK Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the “License”);
+// you may not use this file except in compliance with the License.
+// See [CONTRIBUTORS.md] for the list of HomeKit ADK project authors.
+
+#include "mgos.h"
+#include "mgos_hap.h"
+
+#include "HAPPlatform.h"
+
+#ifndef HAVE_NFC
+#define HAVE_NFC 0
+#endif
+
+#if HAVE_NFC
+#include <errno.h>
+#include <unistd.h>
+#endif
+
+void HAPPlatformAccessorySetupNFCUpdateSetupPayload(
+        HAPPlatformAccessorySetupNFCRef setupNFC,
+        const HAPSetupPayload* setupPayload,
+        bool isPairable) {
+    struct mgos_hap_nfc_update_setup_payload_arg arg = {
+        .setupNFC = setupNFC,
+        .setupPayload = setupPayload,
+        .isPairable = isPairable,
+    };
+    mgos_event_trigger(MGOS_HAP_EV_NFC_UPDATE_SETUP_PAYLOAD, &arg);
+}

--- a/src/PAL/HAPPlatformTCPStreamManager.c
+++ b/src/PAL/HAPPlatformTCPStreamManager.c
@@ -40,7 +40,8 @@ bool HAPPlatformTCPStreamManagerIsListenerOpen(HAPPlatformTCPStreamManagerRef tc
 }
 
 static struct mg_connection* HAPMGListenerGetNextPendingConnection(HAPPlatformTCPStreamManagerRef tm) {
-    if (tm->listener == NULL) return NULL;  // Stopping.
+    if (tm->listener == NULL)
+        return NULL; // Stopping.
     struct mg_mgr* mgr = tm->listener->mgr;
     struct mg_connection* result = NULL;
     for (struct mg_connection* nc = mg_next(mgr, NULL); nc != NULL; nc = mg_next(mgr, nc)) {

--- a/src/mgos_homekit_adk.c
+++ b/src/mgos_homekit_adk.c
@@ -108,16 +108,16 @@ static void load_setup_info_cb(int ev, void* ev_data, void* userdata) {
 
 static void load_setup_id_cb(int ev, void* ev_data, void* userdata) {
 
-    LOG(LL_INFO, ("%s: Loading setup identifier...", __func__));
+    LOG(LL_DEBUG, ("%s: Loading setup identifier...", __func__));
 
     struct mgos_hap_load_setup_id_arg* arg = (struct mgos_hap_load_setup_id_arg*) ev_data;
 
     if (!mgos_hap_setup_id_from_string(arg->setupID, mgos_sys_config_get_hap_setupid())) {
-        LOG(LL_ERROR, ("Failed to load or generate HAP accessory setup identifier!"));
+        LOG(LL_DEBUG, ("Failed to load or generate HAP accessory setup identifier!"));
         *arg->valid = false;
     } else {
         *arg->valid = true;
-        LOG(LL_INFO, ("Success loading setup id. (Identifier is \"%s\")", arg->setupID->stringValue));
+        LOG(LL_DEBUG, ("Success loading setup id. (Identifier is \"%s\")", arg->setupID->stringValue));
     }
 
     (void) ev;


### PR DESCRIPTION
- Added hap.setupid configuration option.
- Moved display and nfc event emitting functions for transparency to the corresponding platform abstraction layer files
- Added setup identifier loading for hap simple configuration. If none was supplied, generate a unique one.
